### PR TITLE
Add time left to reset metric

### DIFF
--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/github"
@@ -21,9 +22,10 @@ func GetRemainingLimits(c *github.Client) RateLimits {
 	}
 
 	return RateLimits{
-		Limit:     limits.Core.Limit,
-		Remaining: limits.Core.Remaining,
-		Used:      limits.Core.Limit - limits.Core.Remaining,
+		Limit:       limits.Core.Limit,
+		Remaining:   limits.Core.Remaining,
+		Used:        limits.Core.Limit - limits.Core.Remaining,
+		SecondsLeft: time.Until(limits.Core.Reset.Time).Seconds(),
 	}
 }
 

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -1,8 +1,10 @@
 package github_client
 
 import (
+	"math"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -11,9 +13,10 @@ import (
 
 func TestGetRemainingLimits(t *testing.T) {
 	var (
-		limit     = 100
-		remaining = 63
-		used      = 37
+		limit        = 100
+		remaining    = 63
+		used         = 37
+		seconds_left = 1500
 	)
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
@@ -25,7 +28,7 @@ func TestGetRemainingLimits(t *testing.T) {
 					Core: &github.Rate{
 						Limit:     limit,
 						Remaining: remaining,
-						Reset:     github.Timestamp{},
+						Reset:     github.Timestamp{Time: time.Now().Add(time.Second * time.Duration(seconds_left))},
 					},
 					Search: &github.Rate{},
 				},
@@ -38,10 +41,12 @@ func TestGetRemainingLimits(t *testing.T) {
 	assert.Equal(t, limit, limits.Limit, "The limits should be equal")
 	assert.Equal(t, remaining, limits.Remaining, "The remaining limits should be equal")
 	assert.Equal(t, used, limits.Used, "The used value should be equal")
+	assert.Equal(t, seconds_left, int(math.Ceil(limits.SecondsLeft)), "The seconds left value should be equal")
 
 	assert.NotEqual(t, 99, limits.Limit, "The limit should not be equal")
 	assert.NotEqual(t, 99, limits.Remaining, "The remaining limits should not be equal")
 	assert.NotEqual(t, 18, limits.Used, "The used value should not be equal")
+	assert.NotEqual(t, 18, limits.Used, "The seconds left value should not be equal")
 }
 
 func TestInitConfigApp(t *testing.T) {

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -13,9 +13,10 @@ type TokenConfig struct {
 }
 
 type RateLimits struct {
-	Limit     int
-	Remaining int
-	Used      int
+	Limit       int
+	Remaining   int
+	Used        int
+	SecondsLeft float64
 }
 
 type GithubClient interface {

--- a/internal/prometheus_exporter/server.go
+++ b/internal/prometheus_exporter/server.go
@@ -32,6 +32,11 @@ func newLimitsCollector() *LimitsCollector {
 			nil, prometheus.Labels{
 				"account": githubAccount,
 			}),
+		SecondsLeft: prometheus.NewDesc(prometheus.BuildFQName("github", "limit", "time_left_seconds"),
+			"Time left in seconds until rate limit gets reset for the installation",
+			nil, prometheus.Labels{
+				"account": githubAccount,
+			}),
 	}
 }
 
@@ -39,6 +44,7 @@ func (collector *LimitsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.LimitTotal
 	ch <- collector.LimitRemaining
 	ch <- collector.LimitUsed
+	ch <- collector.SecondsLeft
 }
 
 func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
@@ -52,12 +58,15 @@ func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(limits.Limit))
 	m2 := prometheus.MustNewConstMetric(collector.LimitRemaining, prometheus.GaugeValue, float64(limits.Remaining))
 	m3 := prometheus.MustNewConstMetric(collector.LimitUsed, prometheus.GaugeValue, float64(limits.Used))
+	m4 := prometheus.MustNewConstMetric(collector.SecondsLeft, prometheus.GaugeValue, limits.SecondsLeft)
 	m1 = prometheus.NewMetricWithTimestamp(time.Now(), m1)
 	m2 = prometheus.NewMetricWithTimestamp(time.Now(), m2)
 	m3 = prometheus.NewMetricWithTimestamp(time.Now(), m3)
+	m4 = prometheus.NewMetricWithTimestamp(time.Now(), m4)
 	ch <- m1
 	ch <- m2
 	ch <- m3
+	ch <- m4
 }
 
 func Run() {

--- a/internal/prometheus_exporter/server_test.go
+++ b/internal/prometheus_exporter/server_test.go
@@ -16,6 +16,7 @@ type FakeCollector struct {
 	LimitTotal     *prometheus.Desc
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
+	SecondsLeft    *prometheus.Desc
 }
 
 func newFakeCollector() *LimitsCollector {
@@ -29,6 +30,9 @@ func newFakeCollector() *LimitsCollector {
 		LimitUsed: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_used"),
 			"Amount of used requests for the installation",
 			nil, nil),
+		SecondsLeft: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "seconds_left"),
+			"Time left in seconds until limit is reset for the installation",
+			nil, nil),
 	}
 }
 
@@ -36,6 +40,7 @@ func (collector *FakeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.LimitTotal
 	ch <- collector.LimitRemaining
 	ch <- collector.LimitUsed
+	ch <- collector.SecondsLeft
 }
 
 func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
@@ -46,12 +51,15 @@ func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(10))
 	m2 := prometheus.MustNewConstMetric(collector.LimitRemaining, prometheus.GaugeValue, float64(6))
 	m3 := prometheus.MustNewConstMetric(collector.LimitUsed, prometheus.GaugeValue, float64(4))
+	m4 := prometheus.MustNewConstMetric(collector.SecondsLeft, prometheus.GaugeValue, time.Duration(time.Second*30).Seconds())
 	m1 = prometheus.NewMetricWithTimestamp(time.Now().Add(-time.Hour), m1)
 	m2 = prometheus.NewMetricWithTimestamp(time.Now(), m2)
 	m3 = prometheus.NewMetricWithTimestamp(time.Now(), m3)
+	m4 = prometheus.NewMetricWithTimestamp(time.Now(), m4)
 	ch <- m1
 	ch <- m2
 	ch <- m3
+	ch <- m4
 }
 
 func TestNewLimitsCollector(t *testing.T) {

--- a/internal/prometheus_exporter/types.go
+++ b/internal/prometheus_exporter/types.go
@@ -6,4 +6,5 @@ type LimitsCollector struct {
 	LimitTotal     *prometheus.Desc
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
+	SecondsLeft    *prometheus.Desc
 }


### PR DESCRIPTION
Related to https://github.com/grafana/deployment_tools/issues/57108

I've forked the repo to be able to gather how long in seconds until the rate limit gets reset for this user

```
# HELP github_rate_limit_remaining Amount of remaining requests for the installation
# TYPE github_rate_limit_remaining gauge
github_rate_limit_remaining{account="mebot"} 5000 1678890475424
# HELP github_rate_limit_time_left_seconds Time left in seconds until rate limit gets reset for the installation
# TYPE github_rate_limit_time_left_seconds gauge
github_rate_limit_time_left_seconds{account="mebot"} 3599.575833993 1678890475424
# HELP github_rate_limit_total Total limit of requests for the installation
# TYPE github_rate_limit_total gauge
github_rate_limit_total{account="mebot"} 5000 1678890475424
# HELP github_rate_limit_used Amount of used requests for the installation
# TYPE github_rate_limit_used gauge
github_rate_limit_used{account="mebot"} 0 1678890475424
```