### PR TITLE
Revert allowing for multiple accounts

### DIFF
--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -2,6 +2,7 @@ package github_client
 
 import (
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -49,36 +50,42 @@ func TestGetRemainingLimits(t *testing.T) {
 }
 
 func TestInitConfigApp(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TYPE", "APP")
+	os.Setenv("GITHUB_APP_ID", "1")
+	os.Setenv("GITHUB_INSTALLATION_ID", "1")
+	os.Setenv("GITHUB_PRIVATE_KEY_PATH", "/home")
+
 	testAuth := AppConfig{
 		AppID:          1,
 		InstallationID: 1,
 		PrivateKeyPath: "/home",
 	}
 
-	account := Account{
-		AuthType:       AuthTypeApp,
-		AppID:          1,
-		InstallationID: 1,
-		PrivateKeyPath: "/home",
-	}
-
-	appInitConfig := InitConfig(&account)
+	appInitConfig := InitConfig()
 
 	assert.Equal(t, appInitConfig, testAuth, "should be equal")
+
 }
 
 func TestInitConfigPAT(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TYPE", "PAT")
+	os.Setenv("GITHUB_TOKEN", "token_ahsd")
+
 	testAuth := TokenConfig{
 		Token: "token_ahsd",
 	}
 
-	account := Account{
-		AuthType: AuthTypePAT,
-		Token:    "token_ahsd",
-	}
+	patInitConfig := InitConfig()
 
-	patInitConfig := InitConfig(&account)
+	assert.Equal(t, patInitConfig, testAuth, "should be equal")
 
-	assert.Equal(t, testAuth, patInitConfig, "should be equal")
+}
+
+func TestInitConfigFailure(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TYPE", "test")
+
+	patInitConfig := InitConfig()
+
+	assert.Equal(t, nil, patInitConfig)
 
 }

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -1,11 +1,6 @@
 package github_client
 
-import (
-	"encoding/json"
-	"errors"
-
-	"github.com/google/go-github/github"
-)
+import "github.com/google/go-github/github"
 
 type AppConfig struct {
 	AppID          int64
@@ -26,40 +21,4 @@ type RateLimits struct {
 
 type GithubClient interface {
 	InitClient() *github.Client
-}
-
-type Account struct {
-	AuthType       AuthType `json:"auth_type"`
-	AccountName    string   `json:"account_name"`
-	AppID          int64    `json:"app_id"`
-	InstallationID int64    `json:"installation_id"`
-	PrivateKeyPath string   `json:"private_key_path"`
-	Token          string   `json:"token"`
-}
-
-type AuthType string
-
-const (
-	AuthTypePAT AuthType = "PAT"
-	AuthTypeApp AuthType = "APP"
-)
-
-var ErrInvalidAuthType = errors.New("invalid auth type")
-
-func (a AuthType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(a))
-}
-
-func (a *AuthType) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-
-	if s == string(AuthTypePAT) || s == string(AuthTypeApp) {
-		*a = AuthType(s)
-		return nil
-	}
-
-	return ErrInvalidAuthType
 }

--- a/internal/prometheus_exporter/server_test.go
+++ b/internal/prometheus_exporter/server_test.go
@@ -5,15 +5,11 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/kalgurn/github-rate-limits-prometheus-exporter/internal/github_client"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/stretchr/testify/assert"
 )
 
 type FakeCollector struct {
@@ -21,24 +17,22 @@ type FakeCollector struct {
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
 	SecondsLeft    *prometheus.Desc
-	Account        *github_client.Account
 }
 
-func newFakeCollector(a *github_client.Account) *LimitsCollector {
+func newFakeCollector() *LimitsCollector {
 	return &LimitsCollector{
-		LimitTotal: prometheus.NewDesc("limit_total",
+		LimitTotal: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_total"),
 			"Total limit of requests for the installation",
 			nil, nil),
-		LimitRemaining: prometheus.NewDesc("limit_remaining",
+		LimitRemaining: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_remaining"),
 			"Amount of remaining requests for the installation",
 			nil, nil),
-		LimitUsed: prometheus.NewDesc("limit_used",
+		LimitUsed: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_used"),
 			"Amount of used requests for the installation",
 			nil, nil),
-		SecondsLeft: prometheus.NewDesc("seconds_left",
+		SecondsLeft: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "seconds_left"),
 			"Time left in seconds until limit is reset for the installation",
 			nil, nil),
-		Account: a,
 	}
 }
 
@@ -51,7 +45,7 @@ func (collector *FakeCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
 
-	log.Printf("Collecting metrics for %s", collector.Account.AccountName)
+	log.Printf("Collecting metrics for %s", githubAccount)
 	//Write latest value for each metric in the prometheus metric channel.
 	//Note that you can pass CounterValue, GaugeValue, or UntypedValue types here.
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(10))
@@ -69,8 +63,7 @@ func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func TestNewLimitsCollector(t *testing.T) {
-	account := github_client.Account{AccountName: "GitHub account name"}
-	newCollector := newFakeCollector(&account)
+	newCollector := newFakeCollector()
 	prometheus.MustRegister(newCollector)
 
 	mux := http.NewServeMux()
@@ -85,87 +78,5 @@ func TestNewLimitsCollector(t *testing.T) {
 		log.Print(err)
 	}
 	fmt.Println(resp)
-}
 
-func TestParseAccountsList(t *testing.T) {
-	os.Setenv(
-		"ACCOUNTS",
-		`[
-			{"auth_type":"PAT","account_name":"bot1","token":"asdf"},
-			{"auth_type":"APP","app_id":1234,"installation_id":67809,"private_key_path":"/home","account_name":"bot2"}
-		]`,
-	)
-
-	expected := []github_client.Account{
-		{
-			AccountName: "bot1",
-			AuthType:    github_client.AuthTypePAT,
-			Token:       "asdf",
-		},
-		{
-			AccountName:    "bot2",
-			AuthType:       github_client.AuthTypeApp,
-			AppID:          1234,
-			InstallationID: 67809,
-			PrivateKeyPath: "/home",
-		},
-	}
-
-	r, _ := getAccountsList()
-
-	assert.True(t, reflect.DeepEqual(expected, r))
-}
-
-func TestSingleAccountRunsOnEnvVarsPAT(t *testing.T) {
-	os.Setenv("GITHUB_AUTH_TYPE", "PAT")
-	os.Setenv("GITHUB_ACCOUNT_NAME", "A name")
-	os.Setenv("GITHUB_TOKEN", "token_ahsd")
-
-	expected := github_client.Account{
-		AccountName: "A name",
-		AuthType:    "PAT",
-		Token:       "token_ahsd",
-	}
-
-	result, _ := getSingleAccount()
-	assert.True(t, reflect.DeepEqual(&expected, result))
-}
-
-func TestSingleAccountRunsOnEnvVarsAPP(t *testing.T) {
-	os.Setenv("GITHUB_AUTH_TYPE", "APP")
-	os.Setenv("GITHUB_ACCOUNT_NAME", "Another name")
-	os.Setenv("GITHUB_APP_ID", "12")
-	os.Setenv("GITHUB_INSTALLATION_ID", "24")
-	os.Setenv("GITHUB_PRIVATE_KEY_PATH", "/tmp")
-
-	expected := github_client.Account{
-		AccountName:    "Another name",
-		AuthType:       "APP",
-		AppID:          12,
-		InstallationID: 24,
-		PrivateKeyPath: "/tmp",
-	}
-
-	result, _ := getSingleAccount()
-	assert.True(t, reflect.DeepEqual(&expected, result))
-}
-
-func TestSingleAccountFailsOnInvalidAuthType(t *testing.T) {
-	os.Setenv("GITHUB_AUTH_TYPE", "POT")
-
-	err := runSingleAccount()
-	assert.NotNil(t, err)
-}
-
-func TestMultipleAccountFailsIfAnyInvalidAuthType(t *testing.T) {
-	os.Setenv(
-		"ACCOUNTS",
-		`[
-			{"auth_type":"PAT","account_name":"bot1","token":"asdf"},
-			{"auth_type":"OOPS","app_id":1234,"installation_id":67809,"private_key_path":"/home","account_name":"bot2"}
-		]`,
-	)
-
-	err := runMultipleAccounts()
-	assert.NotNil(t, err)
 }

--- a/internal/prometheus_exporter/types.go
+++ b/internal/prometheus_exporter/types.go
@@ -1,14 +1,10 @@
 package prometheus_exporter
 
-import (
-	"github.com/kalgurn/github-rate-limits-prometheus-exporter/internal/github_client"
-	"github.com/prometheus/client_golang/prometheus"
-)
+import "github.com/prometheus/client_golang/prometheus"
 
 type LimitsCollector struct {
 	LimitTotal     *prometheus.Desc
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
 	SecondsLeft    *prometheus.Desc
-	Account        *github_client.Account
 }


### PR DESCRIPTION
After playing around with this funcionality, it looks like the tradeoff adds a lot of complexity that's not really worth the effort. It's way easier to just run as many exporters as you need/want, each with its own configuration.

So, reverting back to the original code design.