### PR TITLE
Retrieve InstallationID by OrgName or RepoName

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v50 v50.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,24 @@
 module github.com/kalgurn/github-rate-limits-prometheus-exporter
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.2.0
-	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v65 v65.0.0
 	github.com/migueleliasweb/go-github-mock v0.0.16
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/oauth2 v0.6.0
 )
 
-require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+require github.com/golang-jwt/jwt/v5 v5.2.1
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v50 v50.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	golang.org/x/oauth2 v0.6.0
 )
 
+require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
@@ -120,13 +118,14 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v50 v50.0.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
 github.com/google/go-github/v50 v50.1.0 h1:hMUpkZjklC5GJ+c3GquSqOP/T4BNsB7XohaPhtMOzRk=
 github.com/google/go-github/v50 v50.1.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
+github.com/google/go-github/v65 v65.0.0 h1:pQ7BmO3DZivvFk92geC0jB0q2m3gyn8vnYPgV7GSLhQ=
+github.com/google/go-github/v65 v65.0.0/go.mod h1:DvrqWo5hvsdhJvHd4WyVF9ttANN3BniqjP8uTFMNb60=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -48,14 +48,15 @@ func (c AppConfig) InitClient() *github.Client {
 		}
 		client := auth.InitClient()
 
+		var err error
+		var installation *github.Installation
 		ctx := context.Background()
-		installation, _, err := client.Apps.FindOrganizationInstallation(ctx, c.OrgName)
-		utils.RespError(err)
-
 		if c.RepoName != "" {
 			installation, _, err = client.Apps.FindRepositoryInstallation(ctx, c.OrgName, c.RepoName)
-			utils.RespError(err)
+		} else {
+			installation, _, err = client.Apps.FindOrganizationInstallation(ctx, c.OrgName)
 		}
+		utils.RespError(err)
 
 		c.InstallationID = installation.GetID()
 	}
@@ -85,7 +86,7 @@ func InitConfig() GithubClient {
 		var installationID int64
 		envInstallationID := utils.GetOSVar("GITHUB_INSTALLATION_ID")
 		if envInstallationID != "" {
-			installationID, _ = strconv.ParseInt(utils.GetOSVar("GITHUB_INSTALLATION_ID"), 10, 64)
+			installationID, _ = strconv.ParseInt(envInstallationID, 10, 64)
 		}
 
 		auth = AppConfig{

--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/kalgurn/github-rate-limits-prometheus-exporter/internal/utils"
 	"golang.org/x/oauth2"
 )
@@ -18,7 +18,7 @@ import (
 func GetRemainingLimits(c *github.Client) RateLimits {
 	ctx := context.Background()
 
-	limits, _, err := c.RateLimits(ctx)
+	limits, _, err := c.RateLimit.Get(ctx)
 	if err != nil {
 		utils.RespError(err)
 	}

--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/github"
 	"github.com/kalgurn/github-rate-limits-prometheus-exporter/internal/utils"
 	"golang.org/x/oauth2"
@@ -115,10 +115,10 @@ func generateJWT(appID int64, privateKeyPath string) string {
 	utils.RespError(err)
 
 	now := time.Now()
-	claims := jwt.StandardClaims{
+	claims := jwt.RegisteredClaims{
 		Issuer:    fmt.Sprintf("%d", appID),
-		IssuedAt:  now.Unix(),
-		ExpiresAt: now.Add(time.Minute * 10).Unix(),
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -1,15 +1,51 @@
 package github_client
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 )
+
+func generateTestPrivateKey(t *testing.T) (string, *rsa.PrivateKey) {
+	// Generate RSA private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA private key: %v", err)
+	}
+
+	// Convert private key to PEM format
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+
+	// Write private key to a temp file
+	tempKeyFile, err := os.CreateTemp("", "testkey")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tempKeyFile.Close()
+
+	if _, err := tempKeyFile.Write(privateKeyPEM); err != nil {
+		t.Fatalf("Failed to write to temp key file: %v", err)
+	}
+
+	return tempKeyFile.Name(), privateKey
+}
 
 func TestGetRemainingLimits(t *testing.T) {
 	var (
@@ -55,7 +91,7 @@ func TestInitConfigApp(t *testing.T) {
 	os.Setenv("GITHUB_INSTALLATION_ID", "1")
 	os.Setenv("GITHUB_PRIVATE_KEY_PATH", "/home")
 
-	testAuth := AppConfig{
+	testAuth := &AppConfig{
 		AppID:          1,
 		InstallationID: 1,
 		PrivateKeyPath: "/home",
@@ -71,7 +107,7 @@ func TestInitConfigPAT(t *testing.T) {
 	os.Setenv("GITHUB_AUTH_TYPE", "PAT")
 	os.Setenv("GITHUB_TOKEN", "token_ahsd")
 
-	testAuth := TokenConfig{
+	testAuth := &TokenConfig{
 		Token: "token_ahsd",
 	}
 
@@ -96,7 +132,7 @@ func TestInitConfigAppWithoutInstallationID(t *testing.T) {
 	os.Setenv("GITHUB_ORG_NAME", "org")
 	os.Setenv("GITHUB_PRIVATE_KEY_PATH", "/home")
 
-	testAuth := AppConfig{
+	testAuth := &AppConfig{
 		AppID:          1,
 		OrgName:        "org",
 		PrivateKeyPath: "/home",
@@ -105,4 +141,122 @@ func TestInitConfigAppWithoutInstallationID(t *testing.T) {
 	appInitConfig := InitConfig()
 
 	assert.Equal(t, appInitConfig, testAuth, "should be equal")
+}
+
+func TestAppConfig_InitClient(t *testing.T) {
+	testCases := []struct {
+		name              string
+		orgName           string
+		repoName          string
+		providedInstallID int64 // InstallationID provided directly in AppConfig
+		expectedInstallID int64 // Expected InstallationID after InitClient
+		expectedPattern   string
+		method            string
+	}{
+		{
+			name:              "WithInstallationID",
+			orgName:           "",
+			repoName:          "",
+			providedInstallID: 654321,
+			expectedInstallID: 654321,
+			expectedPattern:   "", // No API call expected
+			method:            "",
+		},
+		{
+			name:              "WithOrgName",
+			orgName:           "testorg",
+			repoName:          "",
+			providedInstallID: 0, // To be retrieved via API
+			expectedInstallID: 654321,
+			expectedPattern:   "/orgs/testorg/installation",
+			method:            "GET",
+		},
+		{
+			name:              "WithOrgAndRepoName",
+			orgName:           "testorg",
+			repoName:          "testrepo",
+			providedInstallID: 0, // To be retrieved via API
+			expectedInstallID: 654321,
+			expectedPattern:   "/repos/testorg/testrepo/installation",
+			method:            "GET",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			privateKeyPath, _ := generateTestPrivateKey(t)
+			defer os.Remove(privateKeyPath)
+
+			appID := int64(123456)
+			var httpClient *http.Client
+
+			if tc.expectedPattern != "" {
+				// Create a mock HTTP client to simulate API call
+				mockClient := mock.NewMockedHTTPClient(
+					mock.WithRequestMatchHandler(
+						mock.EndpointPattern{Pattern: tc.expectedPattern, Method: tc.method},
+						http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							// Return mock installation data
+							installation := &github.Installation{
+								ID: github.Int64(tc.expectedInstallID),
+							}
+							data, _ := json.Marshal(installation)
+							w.WriteHeader(http.StatusOK)
+							w.Write(data)
+						}),
+					),
+				)
+				httpClient = mockClient
+			} else {
+				httpClient = nil // No HTTP client needed; no API call expected
+			}
+
+			// Initialize the AppConfig
+			c := &AppConfig{
+				AppID:          appID,
+				InstallationID: tc.providedInstallID,
+				OrgName:        tc.orgName,
+				RepoName:       tc.repoName,
+				PrivateKeyPath: privateKeyPath,
+			}
+
+			client := c.InitClient(httpClient)
+			assert.NotNil(t, client, "Expected client not to be nil")
+
+			assert.Equal(t, tc.expectedInstallID, c.InstallationID, "Expected InstallationID to be set correctly")
+		})
+	}
+}
+
+func TestGenerateJWT(t *testing.T) {
+	privateKeyPath, privateKey := generateTestPrivateKey(t)
+	defer os.Remove(privateKeyPath)
+
+	appID := int64(123456)
+	token := generateJWT(appID, privateKeyPath)
+
+	assert.NotEmpty(t, token, "expected token not to be empty")
+
+	// Verify the token
+	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		return &privateKey.PublicKey, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to parse token: %v", err)
+	}
+
+	assert.True(t, parsedToken.Valid, "the token should be valid")
+
+	// Check claims
+	if claims, ok := parsedToken.Claims.(jwt.MapClaims); ok {
+		issuer := claims["iss"]
+		assert.Equal(t, fmt.Sprintf("%d", appID), issuer, "expected issuer to be equal app id")
+
+		exp := int64(claims["exp"].(float64))
+		now := time.Now().Unix()
+		assert.LessOrEqual(t, now, exp, "expected token to not be expired")
+	} else {
+		t.Error("Failed to parse claims")
+	}
 }

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -89,3 +89,20 @@ func TestInitConfigFailure(t *testing.T) {
 	assert.Equal(t, nil, patInitConfig)
 
 }
+
+func TestInitConfigAppWithoutInstallationID(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TYPE", "APP")
+	os.Setenv("GITHUB_APP_ID", "1")
+	os.Setenv("GITHUB_ORG_NAME", "org")
+	os.Setenv("GITHUB_PRIVATE_KEY_PATH", "/home")
+
+	testAuth := AppConfig{
+		AppID:          1,
+		OrgName:        "org",
+		PrivateKeyPath: "/home",
+	}
+
+	appInitConfig := InitConfig()
+
+	assert.Equal(t, appInitConfig, testAuth, "should be equal")
+}

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -220,7 +220,7 @@ func TestAppConfig_InitClient(t *testing.T) {
 				PrivateKeyPath: privateKeyPath,
 			}
 
-			client := c.InitClient(httpClient)
+			client := initAppClient(c, httpClient)
 			assert.NotNil(t, client, "Expected client not to be nil")
 
 			assert.Equal(t, tc.expectedInstallID, c.InstallationID, "Expected InstallationID to be set correctly")

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -168,7 +168,7 @@ func TestAppConfig_InitClient(t *testing.T) {
 			repoName:          "",
 			providedInstallID: 0, // To be retrieved via API
 			expectedInstallID: 654321,
-			expectedPattern:   "/orgs/testorg/installation",
+			expectedPattern:   "/orgs/{org}/installation",
 			method:            "GET",
 		},
 		{
@@ -177,7 +177,7 @@ func TestAppConfig_InitClient(t *testing.T) {
 			repoName:          "testrepo",
 			providedInstallID: 0, // To be retrieved via API
 			expectedInstallID: 654321,
-			expectedPattern:   "/repos/testorg/testrepo/installation",
+			expectedPattern:   "/repos/{owner}/{repo}/installation",
 			method:            "GET",
 		},
 	}

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -5,6 +5,8 @@ import "github.com/google/go-github/github"
 type AppConfig struct {
 	AppID          int64
 	InstallationID int64
+	OrgName        string
+	RepoName       string
 	PrivateKeyPath string
 }
 

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -1,8 +1,6 @@
 package github_client
 
 import (
-	"net/http"
-
 	"github.com/google/go-github/github"
 )
 
@@ -26,5 +24,5 @@ type RateLimits struct {
 }
 
 type GithubClient interface {
-	InitClient(httpClient *http.Client) *github.Client
+	InitClient() *github.Client
 }

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -1,6 +1,10 @@
 package github_client
 
-import "github.com/google/go-github/github"
+import (
+	"net/http"
+
+	"github.com/google/go-github/github"
+)
 
 type AppConfig struct {
 	AppID          int64
@@ -22,5 +26,5 @@ type RateLimits struct {
 }
 
 type GithubClient interface {
-	InitClient() *github.Client
+	InitClient(httpClient *http.Client) *github.Client
 }

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -1,7 +1,7 @@
 package github_client
 
 import (
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type AppConfig struct {

--- a/internal/prometheus_exporter/server.go
+++ b/internal/prometheus_exporter/server.go
@@ -50,7 +50,7 @@ func (collector *LimitsCollector) Describe(ch chan<- *prometheus.Desc) {
 func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	auth := github_client.InitConfig()
-	limits := github_client.GetRemainingLimits(auth.InitClient())
+	limits := github_client.GetRemainingLimits(auth.InitClient(nil))
 	log.Printf("Collected metrics for %s", githubAccount)
 	log.Printf("Limit: %d | Used: %d | Remaining: %d", limits.Limit, limits.Used, limits.Remaining)
 	//Write latest value for each metric in the prometheus metric channel.

--- a/internal/prometheus_exporter/server.go
+++ b/internal/prometheus_exporter/server.go
@@ -50,7 +50,7 @@ func (collector *LimitsCollector) Describe(ch chan<- *prometheus.Desc) {
 func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	auth := github_client.InitConfig()
-	limits := github_client.GetRemainingLimits(auth.InitClient(nil))
+	limits := github_client.GetRemainingLimits(auth.InitClient())
 	log.Printf("Collected metrics for %s", githubAccount)
 	log.Printf("Limit: %d | Used: %d | Remaining: %d", limits.Limit, limits.Used, limits.Remaining)
 	//Write latest value for each metric in the prometheus metric channel.


### PR DESCRIPTION
Currently the Installation ID is needed to configure the exporter, however this ID is only easily accessible to org admins.

The installation ID can easily be retrived using the App ID and Private Key if you specify the org or repo where the app is installed.

This gives operators the option to configure the app without needing an installation ID, by providing a GITHUB_ORG_NAME and optionally a GITHUB_REPO_NAME.

Previous authentication using GITHUB_INSTALLATION_ID continues to work as normal.