### PR TITLE
chore: update Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:alpine AS build
+FROM golang:1.26.3-alpine AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kalgurn/github-rate-limits-prometheus-exporter
 
-go 1.21
+go 1.24
 
-toolchain go1.21.3
+toolchain go1.26.3
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.2.0


### PR DESCRIPTION
This change mostly affects the tooling within the GitHub workflow. The Docker image was already at "latest".