### PR TITLE
chore: switch ci to target main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
As far as I can tell this is the only element that explicitly references the master branch. The resulting images will now have a tag prefix `main-` instead of `master-` so that's something to keep an eye on while rolling out the next update.

In general, the motivation behind the changed default branch is mostly consistency but also to make it clear that this fork has by now deviated quite a bit from upstream and will most likely continue to do so.